### PR TITLE
Add `HasValue` and `IsKnown` to nullable Single Value Objects

### DIFF
--- a/specs/Qowaiv.CodeGeneration.Specs/SingleValueObjects/Qowaiv_SVO_definitions.cs
+++ b/specs/Qowaiv.CodeGeneration.Specs/SingleValueObjects/Qowaiv_SVO_definitions.cs
@@ -41,6 +41,8 @@ public class Generation_of
 
     [TestCase("StreamSize", typeof(long), "stream size", "Qowaiv.IO", SvoFeatures.Continuous ^ SvoFeatures.Field ^ SvoFeatures.IFormattable)]
 
+    [TestCase("EnergyLabel", typeof(int), "EU energy label", "Qowaiv.Sustainability", SvoFeatures.Default)]
+
     [TestCase("Elo", typeof(double), "elo", "Qowaiv.Statistics", SvoFeatures.Continuous)]
 
     [TestCase("Fraction", typeof(long), "fraction", "Qowaiv.Mathematics", (SvoFeatures.Continuous)
@@ -49,14 +51,14 @@ public class Generation_of
         ^ SvoFeatures.Field)]
 
     [TestCase("InternetMediaType", typeof(string), "Internet media type", "Qowaiv.Web", SvoFeatures.Default)]
-    public void Qowaiv(string name, Type underlying, string fulleName, string ns, SvoFeatures features, string formatExceptionMessage = null)
+    public void Qowaiv(string name, Type underlying, string fullName, string ns, SvoFeatures features, string? formatExceptionMessage = null)
     {
         var sub = ns.Replace("Qowaiv", "").Replace(".", @"\");
         var path = $@"{Root}\src\Qowaiv\Generated\{sub}\{name}.generated.cs".Replace(@"\\", @"\");
         var init = $@"{Root}\src\Qowaiv\{sub}\{name}.cs".Replace(@"\\", @"\");
         var json = $@"{Root}\src\Qowaiv\Json\{sub}\{name}JsonConverter.cs".Replace(@"\\", @"\");
         var spec = $@"{Root}\specs\Qowaiv.Specs\{sub}\{name}_specs.cs".Replace(@"\\", @"\");
-        Generate(name, underlying, fulleName, ns, features, path, init, json, spec, formatExceptionMessage);
+        Generate(name, underlying, fullName, ns, features, path, init, json, spec, formatExceptionMessage);
     }
 
     [TestCase("Timestamp", typeof(ulong), "timestamp", "Qowaiv.Sql", SvoFeatures.Continuous)]
@@ -79,7 +81,7 @@ public class Generation_of
         string init,
         string json,
         string spec,
-        string formatExceptionMessage)
+        string? formatExceptionMessage)
     {
         var arguments = new SvoArguments
         {

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/ISerializable.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/ISerializable.cs
@@ -6,7 +6,7 @@ public partial struct @TSvo : ISerializable
     /// <param name="context">The streaming context.</param>
     private @TSvo(SerializationInfo info, StreamingContext context)
     {
-        Guard.NotNull(info, nameof(info));
+        Guard.NotNull(info);
         m_Value = info.GetValue("Value", typeof(@type)) is @type val ? val : default(@type);
     }
 
@@ -14,6 +14,6 @@ public partial struct @TSvo : ISerializable
     /// <param name="info">The serialization info.</param>
     /// <param name="context">The streaming context.</param>
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-        => Guard.NotNull(info, nameof(info)).AddValue("Value", m_Value);
+        => Guard.NotNull(info).AddValue("Value", m_Value);
 }
 #endif // exec

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/IXmlSerializable.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/IXmlSerializable.cs
@@ -11,7 +11,7 @@
     /// <param name="reader">An XML reader.</param>
     void IXmlSerializable.ReadXml(XmlReader reader)
     {
-        Guard.NotNull(reader, nameof(reader));
+        Guard.NotNull(reader);
         var xml = reader.ReadElementString();
 #if !NotCultureDependent // exec
         System.Runtime.CompilerServices.Unsafe.AsRef(this) = Parse(xml, CultureInfo.InvariantCulture);
@@ -26,5 +26,5 @@
     /// </remarks>
     /// <param name="writer">An XML writer.</param>
     void IXmlSerializable.WriteXml(XmlWriter writer)
-        => Guard.NotNull(writer, nameof(writer)).WriteString(ToXmlString());
+        => Guard.NotNull(writer).WriteString(ToXmlString());
 }

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Specs.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Specs.cs
@@ -30,6 +30,7 @@ public class With_domain_logic
         => svo.IsUnknown().Should().Be(result);
 }
 
+[Obsolete("Will be dropped")]
 public class Is_valid_for
 {
     [TestCase("?")]
@@ -43,6 +44,7 @@ public class Is_valid_for
         => @TSvo.IsValid(input, culture).Should().BeTrue();
 }
 
+[Obsolete("Will be dropped")]
 public class Is_not_valid_for
 {
     [Test]
@@ -65,8 +67,10 @@ public class Is_not_valid_for
 public class Has_constant
 {
     [Test]
-    public void Empty_represent_default_value()
-        => @TSvo.Empty.Should().Be(default(@TSvo));
+    public void Empty() => @TSvo.Empty.Should().Be(default(@TSvo));
+
+    [Test]
+    public void Unknown() => @TSvo.Unknown.Should().Be(@TSvo.Parse("?"));
 }
 
 public class Is_equal_by_value
@@ -216,11 +220,11 @@ public class Has_custom_formatting
 
     [TestCase("en-GB", null, "svoValue", "SvoFormat")]
     [TestCase("nl-BE", "f", "svoValue", "SvoFormat")]
-    public void culture_dependent(CultureInfo culture, string format, @TSvo svo, string expected)
+    public void culture_dependent(CultureInfo culture, string format, @TSvo svo, string formatted)
     {
         using (culture.Scoped())
         {
-            Assert.AreEqual(expected, svo.ToString(format));
+            svo.ToString(format).Should().Be(formatted);
         }
     }
 
@@ -446,6 +450,10 @@ public class Is_Open_API_data_type
            type: "string",
            format: "format",
            pattern: null));
+
+    [TestCase("svoValue")]
+    public void pattern_matches(string input)
+        => Qowaiv.OpenApi.OpenApiDataType.FromType(typeof(@TSvo))!.Matches(input).Should().BeTrue();
 }
 
 public class Supports_binary_serialization
@@ -469,7 +477,7 @@ public class Supports_binary_serialization
 public class Debugger
 {
     [TestCase("{empty}", "")]
-    [TestCase("?", "?")]
+    [TestCase("{unknown}", "?")]
     [TestCase("DebuggerDisplay", "svoValue")]
     public void has_custom_display(object display, @TSvo svo)
         => svo.Should().HaveDebuggerDisplay(display);

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Structure.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/Structure.cs
@@ -10,20 +10,35 @@ public partial struct @TSvo
     private @TSvo(@type_n value) => m_Value = value;
 
     /// <summary>The inner value of the @FullName.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly @type_n m_Value;
 #endif // exec
-
 #if !NotIsEmpty // exec
+
+    /// <summary>False if the @FullName is empty, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool HasValue => m_Value != default;
+#endif // exec
+#if !NotIsEmptyOrUnknown // exec
+
+    /// <summary>False if the @FullName is empty or unknown, otherwise true.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsKnown => m_Value != default && m_Value != Unknown.m_Value;
+#endif // exec
+#if !NotIsEmpty // exec
+
     /// <summary>Returns true if the @FullName is empty, otherwise false.</summary>
     [Pure]
     public bool IsEmpty() => m_Value == default;
 #endif // exec
 #if !NotIsUnknown // exec
+
     /// <summary>Returns true if the @FullName is unknown, otherwise false.</summary>
     [Pure]
     public bool IsUnknown() => m_Value == Unknown.m_Value;
 #endif // exec
 #if !NotIsEmptyOrUnknown // exec
+
     /// <summary>Returns true if the @FullName is empty or unknown, otherwise false.</summary>
     [Pure]
     public bool IsEmptyOrUnknown() => IsEmpty() || IsUnknown();

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/SvoTemplate.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/SvoTemplate.cs
@@ -43,10 +43,12 @@ public sealed class SvoTemplate : Code
 
         static IReadOnlyCollection<Constant> Constants(SvoFeatures features)
         {
-            var constants = new List<Constant>();
-            constants.Add((features & SvoFeatures.Structure) != default
+            var constants = new List<Constant>
+            {
+                (features & SvoFeatures.Structure) != default
                 ? "Structure"
-                : "NotStructure");
+                : "NotStructure"
+            };
 
             foreach (var flag in Enum.GetValues<SvoFeatures>().Where(f => f != SvoFeatures.Structure))
             {


### PR DESCRIPTION
To improve pattern matching, add `HasValue`, and `IsKnown` to Single Value objects.