### PR TITLE
Generate JSON Converter only for .NET 6.0 and higher

### DIFF
--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Qowaiv.CodeGeneration.SingleValueObjects.csproj
@@ -10,9 +10,11 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <PackageId>Qowaiv.CodeGeneration.SingleValueObjects</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageReleaseNotes>
       <![CDATA[
+v1.0.1
+- Generate JSON Converter only for .NET 6.0 and higher.
 v1.0.0
 - Generate custom SVO's.
 ]]>

--- a/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/CustomSvo.cs
+++ b/src/Qowaiv.CodeGeneration.SingleValueObjects/Snippets/CustomSvo.cs
@@ -311,7 +311,17 @@ namespace @Namespace
             result = new @Svo(parsed);
             return success;
         }
+        private sealed class SvoTypeConverter : global::Qowaiv.Conversion.SvoTypeConverter<@Svo>
+        {
+            /// <inheritdoc />
+            [global::System.Diagnostics.Contracts.Pure]
+            protected override @Svo FromString(string? str, global::System.Globalization.CultureInfo? culture)
+            {
+                return Parse(str, culture);
+            }
+        }
 
+#if NET6_0_OR_GREATER
         private sealed class SvoJsonConverter : global::Qowaiv.Json.SvoJsonConverter<@Svo>
         {
             /// <inheritdoc />
@@ -322,15 +332,6 @@ namespace @Namespace
             [global::System.Diagnostics.Contracts.Pure]
             protected override object? ToJson(@Svo svo) => svo.ToJson();
         }
-
-        private sealed class SvoTypeConverter : global::Qowaiv.Conversion.SvoTypeConverter<@Svo>
-        {
-            /// <inheritdoc />
-            [global::System.Diagnostics.Contracts.Pure]
-            protected override @Svo FromString(string? str, global::System.Globalization.CultureInfo? culture)
-            {
-                return Parse(str, culture);
-            }
-        }
-    } 
+#endif
+    }
 }


### PR DESCRIPTION
Code is not available before .NET 6.0.